### PR TITLE
fix: 兼容 publicPath 为绝对路径的 url 的情况

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -22,7 +22,18 @@
         "doc",
         "maintenance"
       ]
+    },
+    {
+      "login": "gd4Ark",
+      "name": "4Ark",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/27952659?v=4",
+      "profile": "https://4ark.me",
+      "contributions": [
+        "doc",
+        "translation"
+      ]
     }
   ],
-  "contributorsPerLine": 7
+  "contributorsPerLine": 7,
+  "skipCi": true
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -22,7 +22,7 @@
 
 ## Features
 
-Check if the current application is the latest version. If not, it reminds you to reload the current page.
+检测当前运行的应用是否是最新版本，如若不是，则提醒刷新以使用新版本。
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -36,33 +36,33 @@ yarn add @femessage/update-popup
 
 ## Usage
 
-You need to set environment variables `UPDATE_POPUP_VERSION`, when iteratively updating, modify the variables greater than current value.
+你需要通过环境变量 `UPDATE_POPUP_VERSION` 来传入版本号，后续每次迭代更新只需要修改比当前大的版本号即可。
 
-Environment variables
+环境变量
 
 ```bash
 # .env
-UPDATE_POPUP_VERSION=1.0.0 # Support more. e.g.: 1.0.0.1, 1.0.0.1.1
+UPDATE_POPUP_VERSION=1.0.0 # 如果有必要，可以支持更多位数。如：1.0.0.1，1.0.0.1.1
 ```
 
-Project configuration file
+工程配置文件
 
 ```js
 // nuxt.config.js
 const config = {
-  modules: ['@femessage/update-popup/nuxt', {options}],
+  modules: ['@femessage/update-popup/nuxt', {options}]
 }
 
-// vue.config.js or poi.config.js
+// vue.config.js 或者 poi.config.js
 const UpdatePopup = require('@femessage/update-popup')
 const config = {
-  chainWebpack: (config) => {
+  chainWebpack: config => {
     config.plugin('femessage-update-popup').use(UpdatePopup, [{options}])
-  },
+  }
 }
 ```
 
-It's so easy.
+就这么简单！
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -74,7 +74,7 @@ It's so easy.
 - Default: `webpackConfig.output.publicPath`
 - Reference: [webpack publicPath](https://webpack.docschina.org/configuration/output/#outputpublicpath)
 
-Use publicPath setting
+使用独立的 publicPath，一般情况下不需要设置此参数。
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -83,35 +83,35 @@ Use publicPath setting
 - Type: `boolean`
 - Default: `true`
 
-Does it need to be automatically added to the webpack entry file?
-If set `false` Need to manually `@femessage/update-popup/app/main` Inject it into your code.
-When to set this parameter, see [Notice.QianKun](#qiankun)。
+是否自动添加到 webpack 入口文件，一般情况下不需要设置此参数。  
+如果设置为 `false` 需要手动将 `@femessage/update-popup/app/main` 注入到你的代码中。  
+何时需要设置此参数请参阅 [Notice.QianKun（乾坤）](#qiankun乾坤)。
 
 ### options.envKey
 
 - Type: `string`
 - Default: `'UPDATE_POPUP_VERSION'`
 
-Key of the environment variable. e.g. `process.env.UPDATE_POPUP_VERSION=1.0.0`
+指定获取环境变量的 key 。e.g. `process.env.UPDATE_POPUP_VERSION=1.0.0`
 
 ### options.versionFileName
 
 - Type: `string`
 - Default: `'update_popup_version.txt'`
 
-Version filename.
+版本号文件名。
 
 ## Notice
 
-### QianKun
+### QianKun（乾坤）
 
-This plugin automatically generates a common js file and adds it to the webpack entry file,
-however, due to the requirement to **[export lifecycle hooks](https://qiankun.umijs.org/zh/guide/getting-started#1-%E5%AF%BC%E5%87%BA%E7%9B%B8%E5%BA%94%E7%9A%84%E7%94%9F%E5%91%BD%E5%91%A8%E6%9C%9F%E9%92%A9%E5%AD%90)** for the sub-application's entry file.  
-It is necessary to disable the automatic addition of entry files, with the following adjustments:
+此插件会自动生成一个普通的 js 文件并添加到 webpack 入口文件中，  
+但由于子应用的入口文件需要 **[导出生命周期钩子](https://qiankun.umijs.org/zh/guide/getting-started#1-%E5%AF%BC%E5%87%BA%E7%9B%B8%E5%BA%94%E7%9A%84%E7%94%9F%E5%91%BD%E5%91%A8%E6%9C%9F%E9%92%A9%E5%AD%90)** 的要求，  
+因此需要禁止自动添加入口文件，则做如下的调整：
 
-#### Use in sub-applications
+#### 在子应用中使用
 
-Adjust the project configuration file
+调整工程配置文件
 
 ```diff
 # nuxt.config.js
@@ -120,7 +120,7 @@ const config = {
 +  modules: [['@femessage/update-popup/nuxt'], { inject: false }]
 }
 
-# vue.config.js or poi.config.js
+# vue.config.js 或者 poi.config.js
 const config = {
   chainWebpack: config => {
     config.plugin('update-popup').use(UpdatePopup, [{
@@ -130,7 +130,7 @@ const config = {
 }
 ```
 
-Add an entry file in your **Sub-application** at last
+最后在你的**子应用**入口文件添加
 
 ```diff
 + import '@femessage/update-popup/app/main'

--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://evila.me/"><img src="https://avatars3.githubusercontent.com/u/19513289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>EVILLT</b></sub></a><br /><a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Code">💻</a> <a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Tests">⚠️</a> <a href="#ideas-evillt" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Documentation">📖</a> <a href="#maintenance-evillt" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://evila.me/"><img src="https://avatars3.githubusercontent.com/u/19513289?v=4" width="100px;" alt=""/><br /><sub><b>EVILLT</b></sub></a><br /><a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Code">💻</a> <a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Tests">⚠️</a> <a href="#ideas-evillt" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FEMessage/update-popup/commits?author=evillt" title="Documentation">📖</a> <a href="#maintenance-evillt" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://4ark.me"><img src="https://avatars0.githubusercontent.com/u/27952659?v=4" width="100px;" alt=""/><br /><sub><b>4Ark</b></sub></a><br /><a href="https://github.com/FEMessage/update-popup/commits?author=gd4Ark" title="Documentation">📖</a> <a href="#translation-gd4Ark" title="Translation">🌍</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/test/utils/correct-path.test.js
+++ b/test/utils/correct-path.test.js
@@ -20,4 +20,22 @@ describe('测试路径拼接', () => {
       'no-slash.com/index.html'
     )
   })
+
+  test('http 开头', () => {
+    expect(correctPath('http://no-slash.com', 'index.html')).toBe(
+      'http://no-slash.com/index.html'
+    )
+  })
+
+  test('https 开头', () => {
+    expect(correctPath('https://no-slash.com', 'index.html')).toBe(
+      'https://no-slash.com/index.html'
+    )
+  })
+
+  test('// 开头', () => {
+    expect(correctPath('//no-slash.com', 'index.html')).toBe(
+      '//no-slash.com/index.html'
+    )
+  })
 })

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,6 +4,7 @@
  */
 
 const path = require('path')
+const url = require('url')
 const pupa = require('./pupa')
 
 exports.join = path.join
@@ -21,7 +22,7 @@ exports.resolveWebpackEntry = (webpackEntry, opts = {}) => {
   if (isObject(webpackEntry)) {
     return {
       ...webpackEntry,
-      [opts.NAME]: opts.filePath
+      [opts.NAME]: opts.filePath,
     }
   }
 
@@ -37,7 +38,7 @@ exports.resolveWebpackEntry = (webpackEntry, opts = {}) => {
   return {
     // 默认 main
     main: webpackEntry,
-    [opts.NAME]: opts.filePath
+    [opts.NAME]: opts.filePath,
   }
 }
 
@@ -54,8 +55,8 @@ exports.replaceStr = (content, replaceStrMap = {}) => {
 exports.correctPath = (publicPath, ...args) => {
   let p = path.join(publicPath, ...args)
 
-  if (publicPath.slice(0, 2) === '//') {
-    p = '/' + p
+  if (publicPath.startsWith('http') || publicPath.startsWith('//')) {
+    p = url.resolve(publicPath, ...args)
   }
 
   return p


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
以前的写法只支持传入相对路径的 publicPath，因为是使用 `path.join()` 进行拼接，所以传入带协议的 url，就会被转换为路径

## How
在原有的基础上，判断 publicPath 是否一个 绝对路径的 url（http 或者 // 开头

如果是，则使用 `url.resolve()` 拼接 url

## Test
![image](https://user-images.githubusercontent.com/27952659/96426301-a66f3180-122f-11eb-9b40-cf977d5cceca.png)
